### PR TITLE
Compensate for TensorFlow 1.14 changes

### DIFF
--- a/examples/Keras_ResNet50.py
+++ b/examples/Keras_ResNet50.py
@@ -120,9 +120,10 @@ def get_callbacks(args):
     return callbacks
 
 def run_model(args):
-    # Configure the memory optimizer
+    # Configure the memory optimizer and dependency optimizers
     config = tf.ConfigProto()
     config.graph_options.rewrite_options.memory_optimization = rewriter_config_pb2.RewriterConfig.SCHEDULING_HEURISTICS
+    config.graph_options.rewrite_options.dependency_optimization = rewriter_config_pb2.RewriterConfig.OFF
     K.set_session(tf.Session(config=config))
 
     image_dim = args.image_size

--- a/examples/cnn_mnist_lms.py
+++ b/examples/cnn_mnist_lms.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import numpy as np
 import tempfile  # Change not related to LMS
 import tensorflow as tf
+from tensorflow.core.protobuf import rewriter_config_pb2
 
 tf.logging.set_verbosity(tf.logging.INFO)
 
@@ -131,9 +132,13 @@ def main(unused_argv):
   graph_location = tempfile.mkdtemp()
   print('Saving graph to: %s' % graph_location)
 
+  # Disable dependency optimization for TensorFlow 1.14
+  config = tf.ConfigProto()
+  config.graph_options.rewrite_options.dependency_optimization = rewriter_config_pb2.RewriterConfig.OFF
+  run_config = tf.estimator.RunConfig(session_config=config)
   # Create the Estimator
   mnist_classifier = tf.estimator.Estimator(
-      model_fn=cnn_model_fn, model_dir=graph_location)
+      model_fn=cnn_model_fn, model_dir=graph_location, config=run_config)
 
   # Set up logging for predictions
   # Log the values in the "Softmax" tensor with label "probabilities"

--- a/examples/mnist_deep_lms.py
+++ b/examples/mnist_deep_lms.py
@@ -30,6 +30,7 @@ import argparse
 import sys
 import tempfile
 
+from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.examples.tutorials.mnist import input_data
 
 import tensorflow as tf
@@ -162,7 +163,11 @@ def main(_):
   train_writer = tf.summary.FileWriter(graph_location)
   train_writer.add_graph(tf.get_default_graph())
 
-  with tf.Session() as sess:
+  # Disable dependency optimization for TensorFlow 1.14
+  config = tf.ConfigProto()
+  config.graph_options.rewrite_options.dependency_optimization = rewriter_config_pb2.RewriterConfig.OFF
+
+  with tf.Session(config=config) as sess:
     sess.run(tf.global_variables_initializer())
     for i in range(20000):
       batch = mnist.train.next_batch(50)


### PR DESCRIPTION
TensorFlow 1.14 changes when the optimizer operations are added
to models in the Keras fit_generator flow. It also changes
the named scope of the optimizer operations in Keras models.

For all models, changes to the dependency optimizer cause it
to remove TensorFlow Large Model Support identity swapping nodes.

This compensates for those changes.