### PR TITLE
Fix TensorFlow requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 install_requires = [
-    'tensorflow >= 1.5',
+    'tensorflow-gpu >= 1.5',
     'toposort >= 1.5',
 ]
 


### PR DESCRIPTION
Fix the TensorFlow requirement in setup.py to be "tensorflow-gpu"
rather than "tensorflow". This module is only intended for use
with GPU enabled TensorFlow.

Fixes: #14 